### PR TITLE
Posibbility to add parameters in XSRF handling

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,4 +2,5 @@ import { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
 export default function SapCfAxios(destination: string, instanceConfig?: AxiosRequestConfig, xsrfConfig?: Method | {
     method: Method;
     url: string;
+    params: object;
 }): <T>(req: AxiosRequestConfig) => Promise<AxiosResponse<T>>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -24,12 +24,14 @@ function SapCfAxios(destination, instanceConfig, xsrfConfig = 'options') {
             // handle x-csrf-Token
             const csrfMethod = typeof xsrfConfig === 'string' ? xsrfConfig : (xsrfConfig.method || 'options');
             const csrfUrl = typeof xsrfConfig === 'string' ? req.url : xsrfConfig.url;
+            const csrfParams = typeof xsrfConfig === 'string' ? {} : xsrfConfig.params;
             var tokenReq = {
                 url: csrfUrl,
                 method: csrfMethod,
                 headers: {
                     [req.xsrfHeaderName]: "Fetch"
-                }
+                },
+                params: csrfParams
             };
             try {
                 const { headers } = yield (yield instanceProm)(tokenReq);

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,6 +36,9 @@ function SapCfAxios(destination, instanceConfig, xsrfConfig = 'options') {
             try {
                 const { headers } = yield (yield instanceProm)(tokenReq);
                 const cookies = headers["set-cookie"]; // get cookie from request
+                console.log("GOT COOKIES:");
+                console.log(cookies);
+                console.log(headers);
                 // req.headers = {...req.headers, [req.xsrfHeaderName]: headers[req.xsrfHeaderName]}
                 if (headers) {
                     if (!req.headers)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sap-cf-axios",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,15 @@ export default function SapCfAxios(destination: string, instanceConfig?: AxiosRe
             // handle x-csrf-Token
             const csrfMethod = typeof xsrfConfig === 'string' ? xsrfConfig : (xsrfConfig.method || 'options');
             const csrfUrl = typeof xsrfConfig === 'string' ? req.url : xsrfConfig.url;
+            const csrfParams = xsrfConfig.params ? xsrfConfig.params : { };
 
             var tokenReq: AxiosRequestConfig = {
                 url: csrfUrl,
                 method: csrfMethod,
                 headers: {
                     [req.xsrfHeaderName]: "Fetch"
-                }
+                },
+                params: csrfParams
             };
             try{
                 const { headers } = await (await instanceProm)(tokenReq);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,9 @@ export default function SapCfAxios(destination: string, instanceConfig?: AxiosRe
                 const { headers } = await (await instanceProm)(tokenReq);
                 const cookies = headers["set-cookie"]; // get cookie from request
     
+                console.log("GOT COOKIES:");
+                console.log(cookies);
+                console.log(headers);
                 // req.headers = {...req.headers, [req.xsrfHeaderName]: headers[req.xsrfHeaderName]}
                 if (headers) {
                     if (!req.headers) req.headers = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,14 @@ import enhanceConfig from './configEnhancer';
 
 declare var exports: any;
 
-export default function SapCfAxios(destination: string, instanceConfig?: AxiosRequestConfig, xsrfConfig: Method | {method: Method, url: string} = 'options') {
+export default function SapCfAxios(destination: string, instanceConfig?: AxiosRequestConfig, xsrfConfig: Method | {method: Method, url: string, params: object} = 'options') {
     const instanceProm = createInstance(destination, instanceConfig);
     return async<T>(req: AxiosRequestConfig): Promise<AxiosResponse<T>> => {
         if (req.xsrfHeaderName && req.xsrfHeaderName !== 'X-XSRF-TOKEN') {
             // handle x-csrf-Token
             const csrfMethod = typeof xsrfConfig === 'string' ? xsrfConfig : (xsrfConfig.method || 'options');
             const csrfUrl = typeof xsrfConfig === 'string' ? req.url : xsrfConfig.url;
-            const csrfParams = xsrfConfig.params ? xsrfConfig.params : { };
+            const csrfParams = typeof xsrfConfig === 'string' ? {} : xsrfConfig.params;
 
             var tokenReq: AxiosRequestConfig = {
                 url: csrfUrl,


### PR DESCRIPTION
To be able to choose a specific SAP-Client, I added the possibility to provide parameters to the custom xsrf token fetch method.

Now we can perform post calls to a specific sap client:

![image](https://user-images.githubusercontent.com/9072117/101524212-ef1ead80-3989-11eb-9288-002da2298cc1.png)

