### PR TITLE
simplified axios logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,33 +125,21 @@ function createInstance(destinationName: string, instanceConfig?: SapCFAxiosRequ
 export function logAxiosError(error, logger1: any) {
     const logger = typeof logger1?.error === "function" ? logger1 : log;
     try {
+        logger.error('Error', error.message);
         if (error.response) {
             // The request was made and the server responded with a status code
             // that falls out of the range of 2xx
-            logger.error(error.response.data);
-            logger.error(error.response.status);
-            logger.error(error.response.headers);
-        } else if (error.request) {
-            // The request was made but no response was received
-            // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-            // http.ClientRequest in node.js
-            logger.error(JSON.stringify(error.request));
-        } else if (error.message) {
-            // Something happened in setting up the request that triggered an Error
-            logger.error('Error', error.message);
+            logger.error(JSON.stringify({
+                data: error.response.data,
+                status: error.response.status,
+                headers: error.response.headers
+            }));
         } else {
-            try {
-                logger.error(JSON.stringify(error));
-            } catch (err) {
-                logger.error(error);
-            }
+            logger.error(JSON.stringify(error.toJSON()));
         }
-        if (error.config) {
-            logger.error(JSON.stringify(error.config));
-        }
-    } catch (error) {
-        console.error('Cannot log errors with the given logger');
-        console.error(JSON.stringify(error));
+    } catch (error1) {
+        console.error('Cannot log errors with the given logger', error1);
+        console.error(error);
     }
 
 }


### PR DESCRIPTION
* `JSON.stringify(error.request)` throws a _TypeError: Converting circular structure to JSON_ -> replaced by `JSON.stringify(error.toJSON())`
* `JSON.stringify(error)` returns just `"{}"` -> replaced by `console.error(error)`
* [cf-nodejs-logging-support](https://github.com/SAP/cf-nodejs-logging-support) accepts string only but no json object -> added `JSON.stringify()` for error.response case
* log original error in catch too