### PR TITLE
fixed x-csrf-token fetching error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ function createInstance(destinationName: string, instanceConfig?: SapCFAxiosRequ
                         url: csrfUrl,
                         method: csrfMethod,
                         headers: {
+                            ...(auth) && {authorization: auth},
                             [newConfig.xsrfHeaderName]: "Fetch"
                         },
                         params: csrfParams


### PR DESCRIPTION
x-csrf-token fetching did not work for destinations that require the current JWT token to be forwarded as the authorization header was missing in the token fetch request