### PR TITLE
Added continueOnError property for batch calls

### DIFF
--- a/dist/helper/BatchRequest.d.ts
+++ b/dist/helper/BatchRequest.d.ts
@@ -18,7 +18,7 @@ export default class BatchRequest {
     constructor(reqs: IBatchRequestBodyRequest[], logger: any, size?: number);
     private generateBatchRequests;
     doBatchRequests<T>(url: string, axiosInstance: AxiosInstance, // <T>(req: AxiosRequestConfig) => Promise<AxiosResponse<T>>,
-    doWait?: boolean): Promise<Map<IBatchRequestBodyRequest, T>>;
-    doBatchRequestsParallel<T>(url: string, axiosInstance: AxiosInstance): Promise<Map<IBatchRequestBodyRequest, T>>;
+    doWait?: boolean, continueOnError?: boolean): Promise<Map<IBatchRequestBodyRequest, T>>;
+    doBatchRequestsParallel<T>(url: string, axiosInstance: AxiosInstance, continueOnError?: boolean): Promise<Map<IBatchRequestBodyRequest, T>>;
     private getBatchResponses;
 }

--- a/dist/helper/BatchRequest.js
+++ b/dist/helper/BatchRequest.js
@@ -52,19 +52,20 @@ ${r.body || ""}`)
         });
     }
     doBatchRequests(url, axiosInstance, // <T>(req: AxiosRequestConfig) => Promise<AxiosResponse<T>>,
-    doWait = true) {
+    doWait = true, continueOnError = true) {
         return __awaiter(this, void 0, void 0, function* () {
             let wait = Promise.resolve(true);
             let responses = new Map();
             for (let i = 0; i < this.batchRequests.length && (yield wait); i++) {
                 try {
+                    let additionalHeaders = {};
+                    if (continueOnError)
+                        additionalHeaders["Prefer"] = "odata.continue-on-error";
                     const result = yield axiosInstance({
                         method: "POST",
                         url,
                         data: this.batchRequests[i].payload,
-                        headers: {
-                            "Content-Type": this.batchRequests[i].contentType,
-                        },
+                        headers: Object.assign({ "Content-Type": this.batchRequests[i].contentType }, additionalHeaders)
                     });
                     // next call for LMS can be done in 500 mseconds ... start counting
                     if (doWait)
@@ -80,16 +81,17 @@ ${r.body || ""}`)
             return responses;
         });
     }
-    doBatchRequestsParallel(url, axiosInstance) {
+    doBatchRequestsParallel(url, axiosInstance, continueOnError = true) {
         var _a, _b;
         return __awaiter(this, void 0, void 0, function* () {
+            let additionalHeaders = {};
+            if (continueOnError)
+                additionalHeaders["Prefer"] = "odata.continue-on-error";
             const requests = this.batchRequests.map((b) => axiosInstance({
                 method: "POST",
                 url,
                 data: b.payload,
-                headers: {
-                    "Content-Type": b.contentType,
-                },
+                headers: Object.assign({ "Content-Type": b.contentType }, additionalHeaders),
             }));
             try {
                 return (yield Promise.all(requests)).reduce((acc, resp, i) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sap-cf-axios",
-  "version": "0.4.11",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sap-cf-axios",
-      "version": "0.4.11",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@sap/xsenv": "^4.2.0",

--- a/src/helper/BatchRequest.ts
+++ b/src/helper/BatchRequest.ts
@@ -72,7 +72,7 @@ ${r.body || ""}`
     url: string,
     axiosInstance: AxiosInstance, // <T>(req: AxiosRequestConfig) => Promise<AxiosResponse<T>>,
     doWait = true,
-    continueOnError = true
+    continueOnError = false
   ) {
     let wait = Promise.resolve(true);
     let responses: Map<IBatchRequestBodyRequest, T> = new Map();
@@ -105,7 +105,7 @@ ${r.body || ""}`
     return responses;
   }
 
-  async doBatchRequestsParallel<T>(url: string, axiosInstance: AxiosInstance, continueOnError = true) {
+  async doBatchRequestsParallel<T>(url: string, axiosInstance: AxiosInstance, continueOnError = false) {
 
     let additionalHeaders = {};
     if(continueOnError) additionalHeaders["Prefer"] = "odata.continue-on-error";


### PR DESCRIPTION
Added continueOnError property to determine if batch call should stop on error or not. This will add a header to the batch call.
Default behaviour won't add the header. Property has to be put deliberately on true.